### PR TITLE
feat(email): add export to email functionality

### DIFF
--- a/src/app/dash/[userid]/settings/exports/export.email.tsx
+++ b/src/app/dash/[userid]/settings/exports/export.email.tsx
@@ -4,34 +4,33 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-hot-toast'
 import * as Yup from 'yup'
+import BrandNotionLogo from '@/assets/brand-notion.svg'
 import FieldInput from '../../../../../components/input'
 import { Button, Modal } from '@mantine/core'
-import BrandNotionLogo from '@/assets/brand-notion.svg'
-import BrandFlomoLogo from '@/assets/brand-flomo.png'
 import { ExportDestination, useExportDataToMutation } from '../../../../../schema/generated'
 
-function ExportToFlomo() {
+function ExportToEmail() {
   const [visible, setVisible] = useState(false)
   const { t } = useTranslation()
-  const [mutate] = useExportDataToMutation()
+  const [mutate] = useExportDataToMutation({})
   const formik = useFormik({
     initialValues: {
-      endpoint: '',
+      notionToken: '',
+      notionPageId: ''
     },
     validationSchema: Yup.object({
-      endpoint: Yup.string().url().max(255),
+      notionToken: Yup.string().min(5).max(255),
+      notionPageId: Yup.string().min(5).max(255),
     }),
     onSubmit(vals) {
       // validate
-      if (!vals.endpoint.startsWith('https://flomoapp.com/')) {
-        toast.error(t('app.settings.export.flomo.notFlomo'))
+      if (!formik.isValid || vals.notionPageId.length < 5 || vals.notionToken.length < 5) {
         return
       }
-
       mutate({
         variables: {
-          destination: ExportDestination.Flomo,
-          args: vals.endpoint
+          destination: ExportDestination.Notion,
+          args: `${vals.notionToken}|${vals.notionPageId}`
         }
       }).then(() => {
         toast.success(t('app.settings.export.success'))
@@ -51,43 +50,54 @@ function ExportToFlomo() {
         size='lg'
       >
         <Image
+          src={BrandNotionLogo}
+          width={BrandNotionLogo.width}
+          height={BrandNotionLogo.height}
           className='py-4 px-4'
-          src={BrandFlomoLogo}
-          width={BrandFlomoLogo.width / 2}
-          height={BrandFlomoLogo.height / 2}
-          alt='flomo'
+          alt='notion'
         />
       </Button>
       <Modal
         opened={visible}
-        onClose={() => setVisible(false)}
         centered
-        size='lg'
-        overlayProps={{ backgroundOpacity: 0.55, blur: 8 }}
-        title={t('app.settings.export.flomo.title')}
+        size='xl'
+        onClose={() => setVisible(false)}
+        overlayProps={{ opacity: 0.55, blur: 8 }}
+        title={t('app.settings.export.notion.title')}
       >
         <div className='w-full'>
-          <form className='w-full' onSubmit={formik.handleSubmit}>
+          <iframe
+            src="//player.bilibili.com/player.html?aid=503430935&bvid=BV1Tg411G7gG&cid=349347987&page=1"
+            scrolling="no"
+            allow='fullscreen'
+            className='border-0 w-144 max-h-96 m-auto hidden lg:block'
+            height='768px'
+            width='1024px'
+          />
+          <form className='w-full flex flex-col justify-center items-center' onSubmit={formik.handleSubmit}>
             <FieldInput
-              name='endpoint'
-              value={formik.values.endpoint}
-              error={formik.errors.endpoint}
+              name='notionToken'
+              value={formik.values.notionToken}
+              error={formik.errors.notionToken}
+              onChange={formik.handleChange}
+            />
+            <FieldInput
+              name='notionPageId'
+              value={formik.values.notionPageId}
+              error={formik.errors.notionPageId}
               onChange={formik.handleChange}
             />
             <div
               className='w-full text-right'
             >
-
               <Button
-                // className='w-64 bg-blue-400 rounded py-4 hover:bg-blue-500 duration-150'
                 variant="gradient"
                 className='bg-gradient-to-br from-indigo-400 to-cyan-500'
                 type='submit'
               >
-                {t('app.settings.export.flomo.submit')}
+                {t('app.settings.export.notion.submit')}
               </Button>
             </div>
-
           </form>
         </div>
       </Modal>
@@ -95,4 +105,4 @@ function ExportToFlomo() {
   )
 }
 
-export default ExportToFlomo
+export default ExportToEmail

--- a/src/app/dash/[userid]/settings/exports/export.mail.tsx
+++ b/src/app/dash/[userid]/settings/exports/export.mail.tsx
@@ -1,0 +1,107 @@
+import Image from 'next/image'
+import { useFormik } from 'formik'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'react-hot-toast'
+import * as Yup from 'yup'
+import BrandNotionLogo from '@/assets/brand-notion.svg'
+import FieldInput from '../../../../../components/input'
+import { Button, Modal, TextInput } from '@mantine/core'
+import { ExportDestination, ProfileDocument, ProfileQuery, ProfileQueryVariables, useExportDataToMutation } from '../../../../../schema/generated'
+import { EnvelopeIcon } from '@heroicons/react/24/outline'
+import { useDisclosure } from '@mantine/hooks'
+import { useParams } from 'next/navigation'
+import { useSuspenseQuery } from '@apollo/experimental-nextjs-app-support/ssr';
+
+function ExportToMail() {
+  const [visible, { open, close }] = useDisclosure()
+  const { t } = useTranslation()
+
+  const userDomain = useParams<{ userid: string }>().userid
+  const isTypeUid = !Number.isNaN(parseInt(userDomain))
+  const { data: p } = useSuspenseQuery<ProfileQuery, ProfileQueryVariables>(ProfileDocument, {
+    variables: {
+      id: isTypeUid ? ~~userDomain : undefined,
+      domain: isTypeUid ? undefined : userDomain
+    }
+  })
+
+  const [mutate, { loading }] = useExportDataToMutation({
+    onCompleted() {
+      toast.success(t('app.settings.export.success'))
+      close()
+    },
+    onError(err) {
+      toast.error(err.toString())
+    }
+  })
+
+  const formik = useFormik({
+    initialValues: {
+      endpoint: p.me.email,
+    },
+    validationSchema: Yup.object({
+      endpoint: Yup.string().email().max(255),
+    }),
+    onSubmit(vals) {
+      if (!formik.isValid) {
+        return
+      }
+      return mutate({
+        variables: {
+          destination: ExportDestination.Mail,
+          args: vals.endpoint!
+        }
+      }).then((d) => {
+        if (d.data) {
+          formik.resetForm()
+        }
+        if (d.errors) {
+          formik.setErrors({ endpoint: d.errors[0].message })
+        }
+      })
+    }
+  })
+  return (
+    <React.Fragment>
+      <Button
+        variant="gradient"
+        className='bg-gradient-to-br from-indigo-400 to-cyan-500'
+        onClick={open}
+        size='lg'
+      >
+        <EnvelopeIcon className='w-6 h-6 text-slate-900' />
+        <span className='ml-2 text-slate-900'>{t('app.settings.export.email.button')}</span>
+      </Button>
+      <Modal
+        opened={visible}
+        onClose={close}
+        centered
+        size='lg'
+        overlayProps={{ backgroundOpacity: 0.55, blur: 8 }}
+        title={t('app.settings.export.email.title')}
+      >
+        <form className='w-full' onSubmit={formik.handleSubmit}>
+          <p>{t('app.settings.export.email.tips')}</p>
+          <TextInput
+            placeholder={t('app.settings.export.email.title')}
+            type='email'
+            className='my-4'
+            {...formik.getFieldProps('endpoint')}
+          />
+          <div className='flex justify-end w-full'>
+            <Button
+              type='submit'
+              className='w-full capitalize'
+              loading={loading}
+            >
+              {t('app.settings.export.email.submit')}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </React.Fragment>
+  )
+}
+
+export default ExportToMail

--- a/src/app/dash/[userid]/settings/exports/export.notion.tsx
+++ b/src/app/dash/[userid]/settings/exports/export.notion.tsx
@@ -62,7 +62,7 @@ function ExportToNotion() {
         centered
         size='xl'
         onClose={() => setVisible(false)}
-        overlayProps={{ opacity: 0.55, blur: 8 }}
+        overlayProps={{ backgroundOpacity: 0.55, blur: 8 }}
         title={t('app.settings.export.notion.title')}
       >
         <div className='w-full'>

--- a/src/app/dash/[userid]/settings/exports/page.tsx
+++ b/src/app/dash/[userid]/settings/exports/page.tsx
@@ -3,6 +3,7 @@ import { Divider, Group } from '@mantine/core'
 import React from 'react'
 import ExportToFlomo from './export.flomo'
 import ExportToNotion from './export.notion'
+import ExportToMail from './export.mail'
 
 function Exports() {
   return (
@@ -11,6 +12,8 @@ function Exports() {
         <ExportToFlomo />
         <Divider orientation='vertical' />
         <ExportToNotion />
+        <Divider orientation='vertical' />
+        <ExportToMail />
       </Group>
     </div>
   )

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -216,14 +216,20 @@
       },
       "export": {
         "title": "Export",
-        "success": "exported",
+        "success": "Exporting... Email notification upon completion.",
         "flomo": {
-          "title": "Flomo",
-          "submit": "export to flomo"
+          "title": "Export to Flomo",
+          "submit": "Export to flomo"
         },
         "notion": {
-          "title": "Notion",
-          "submit": "export to notion"
+          "title": "Export to Notion",
+          "submit": "Export to notion"
+        },
+        "email": {
+          "button": "Email",
+          "title": "Export to Email",
+          "tips": "Are you sure you want to export your data to email?",
+          "submit": "Export to email"
         }
       },
       "domain": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -216,7 +216,7 @@
       },
       "export": {
         "title": "데이터 내보내기",
-        "success": "데이터를 내보냈습니다.",
+        "success": "내보내기 작업이 진행 중이며 완료되면 이메일 알림이 전송됩니다.",
         "flomo": {
           "title": "Flomo",
           "submit": "flomo 로 내보내기"
@@ -224,6 +224,12 @@
         "notion": {
           "title": "Notion",
           "submit": "notion 로 내보내기"
+        },
+        "email": {
+          "button": "이메일",
+          "title": "이메일로 내보내기",
+          "tips": "정말 이메일로 내보내시겠습니까?",
+          "submit": "이메일로 내보내기"
         }
       },
       "domain": {

--- a/src/locales/zhCN.json
+++ b/src/locales/zhCN.json
@@ -216,7 +216,7 @@
       },
       "export": {
         "title": "导出数据",
-        "success": "已导出",
+        "success": "正在执行导出作业，完成后会发送邮件通知",
         "flomo": {
           "title": "Flomo",
           "submit": "导出至 flomo"
@@ -224,6 +224,12 @@
         "notion": {
           "title": "Notion",
           "submit": "导出至 notion"
+        },
+        "email": {
+          "button": "邮件",
+          "title": "导出至邮箱",
+          "tips": "你是否确定真的要导出到邮箱",
+          "submit": "导出至邮箱"
         }
       },
       "domain": {


### PR DESCRIPTION
This commit adds the ability to export data to an email address. The user is now able to input their Notion token and Notion page ID and submit the form to initiate the export. Upon successful export, a success message will be displayed.