### PR TITLE
fix: add null safety for book.summary in AI recommendation modal

### DIFF
--- a/src/components/book-recommendation/ai-book-recommendation-modal.tsx
+++ b/src/components/book-recommendation/ai-book-recommendation-modal.tsx
@@ -27,7 +27,7 @@ function AIBookRecommendationModal({ open, onClose, uid, books }: AIBookRecommen
 
   // Create book information string for the API
   const booksInfo = bookList.books.slice(0, 10).map(book =>
-    `Title: ${book.title}, Author: ${book.author}, Summary: ${book.summary.slice(0, 300)}`
+    `Title: ${book.title}, Author: ${book.author}, Summary: ${(book.summary ?? '').slice(0, 300)}`
   ).join('\n') || ''
 
   const { isLoading, error } = useQuery({


### PR DESCRIPTION
Fixes #150

Adds null safety for `book.summary` property in AI book recommendation modal to prevent TypeError when summary is undefined.

**Changes**:
- Changed `book.summary.slice(0, 300)` to `(book.summary ?? '').slice(0, 300)`
- Uses nullish coalescing operator to provide empty string fallback

Generated with [Claude Code](https://claude.ai/code)