### PR TITLE
Enhance book clippings UI with sorting, view modes, and pagination

### DIFF
--- a/src/app/dash/[userid]/book/[bookid]/content.tsx
+++ b/src/app/dash/[userid]/book/[bookid]/content.tsx
@@ -1,16 +1,26 @@
 'use client'
 import { useQuery } from '@apollo/client/react'
+import { BookOpen } from 'lucide-react'
 import { Masonry, useInfiniteLoader } from 'masonic'
-import { useRef } from 'react'
+import { useMemo, useRef, useState } from 'react'
 
-import ClippingItem from '@/components/clipping-item/clipping-item'
+import BookClippingCard from '@/components/clipping-item/book-clipping-card'
+import BookClippingsToolbar, {
+  type ClippingsSortOrder,
+  type ClippingsViewMode,
+} from '@/components/clipping-item/book-clippings-toolbar'
+import InfiniteScrollFooter from '@/components/clipping-item/infinite-scroll-footer'
 import { usePageTrack } from '@/hooks/tracke'
 import { useMasonaryColumnCount } from '@/hooks/use-screen-size'
-import { BookDocument, type BookQuery, type Clipping } from '@/schema/generated'
+import { useTranslation } from '@/i18n/client'
+import { BookDocument, type BookQuery } from '@/schema/generated'
 import { IN_APP_CHANNEL } from '@/services/channel'
 import type { WenquBook } from '@/services/wenqu'
+import { uniqueById } from '@/utils/array'
 
-import BookPageSkeleton from './skeleton'
+export const BOOK_CLIPPINGS_PAGE_SIZE = 12
+
+type BookClippingsItem = NonNullable<BookQuery['book']['clippings']>[number]
 
 type BookPageContentProps = {
   userid: string
@@ -19,67 +29,162 @@ type BookPageContentProps = {
 
 function BookPageContent(props: BookPageContentProps) {
   const { userid: domain, book: bookData } = props
+  const { t } = useTranslation(undefined, 'book')
   usePageTrack('book', {
     bookId: bookData.id,
   })
 
-  const hasMore = useRef(true)
+  const [extraItems, setExtraItems] = useState<BookClippingsItem[]>([])
+  const loadingRef = useRef(false)
+
   const { data: clippingsData, fetchMore } = useQuery<BookQuery>(BookDocument, {
     variables: {
       id: bookData.doubanId,
       pagination: {
-        limit: 10,
-        offset: 0,
+        limit: BOOK_CLIPPINGS_PAGE_SIZE,
       },
     },
+    notifyOnNetworkStatusChange: true,
   })
 
-  const masonaryColumnCount = useMasonaryColumnCount()
-  const maybeLoadMore = useInfiniteLoader(
-    (_, __, currentItems) => {
-      if (!hasMore.current) {
-        return Promise.reject(1)
-      }
-      return fetchMore({
+  const initialClippings = (clippingsData?.book.clippings ?? []) as
+    | BookClippingsItem[]
+    | never[]
+  const totalCount = clippingsData?.book.clippingsCount ?? 0
+
+  // Merge + dedupe server page + loaded pages.
+  const mergedItems = useMemo(
+    () => uniqueById<BookClippingsItem>([...initialClippings, ...extraItems]),
+    [initialClippings, extraItems]
+  )
+
+  const [sort, setSort] = useState<ClippingsSortOrder>('newest')
+  const [view, setView] = useState<ClippingsViewMode>('masonry')
+
+  // Client-side sort of loaded items. A backend `orderBy` arg is a follow-up;
+  // until then this gives the user instant control over loaded rows.
+  const renderList = useMemo(() => {
+    if (mergedItems.length < 2) {
+      return mergedItems
+    }
+    const copy = [...mergedItems]
+    copy.sort((a, b) => {
+      const delta = (b.id as number) - (a.id as number)
+      return sort === 'newest' ? delta : -delta
+    })
+    return copy
+  }, [mergedItems, sort])
+
+  const hasMore = mergedItems.length < totalCount
+  const [loadingMore, setLoadingMore] = useState(false)
+
+  const loadMore = async () => {
+    if (!hasMore || loadingRef.current || mergedItems.length === 0) {
+      return
+    }
+    loadingRef.current = true
+    setLoadingMore(true)
+    try {
+      const lastId = mergedItems[mergedItems.length - 1].id as number
+      const resp = await fetchMore({
         variables: {
           id: bookData.doubanId,
           pagination: {
-            limit: 10,
-            offset: currentItems.length,
+            limit: BOOK_CLIPPINGS_PAGE_SIZE,
+            lastId,
           },
         },
       })
+      const next = (resp.data?.book.clippings ?? []) as BookClippingsItem[]
+      if (next.length > 0) {
+        setExtraItems((prev) => [...prev, ...next])
+      }
+    } finally {
+      loadingRef.current = false
+      setLoadingMore(false)
+    }
+  }
+
+  const masonaryColumnCount = useMasonaryColumnCount()
+  const maybeLoadMore = useInfiniteLoader(
+    async () => {
+      if (!hasMore) {
+        return
+      }
+      await loadMore()
     },
     {
       isItemLoaded: (index, items) => !!items[index],
       threshold: 3,
-      totalItems: clippingsData?.book.clippingsCount,
+      totalItems: totalCount,
     }
   )
 
-  if (!bookData || !clippingsData) {
-    return <BookPageSkeleton />
+  // Initial loading state — rendered by the Suspense skeleton instead.
+  if (!clippingsData) {
+    return null
   }
 
+  // Empty state
+  if (totalCount === 0) {
+    return (
+      <div className="mt-4 flex flex-col items-center justify-center rounded-2xl border border-slate-200/60 bg-white/60 px-6 py-16 text-center backdrop-blur-xl dark:border-slate-700/50 dark:bg-slate-800/50">
+        <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-50 text-blue-400 dark:bg-blue-400/10 dark:text-blue-300">
+          <BookOpen size={28} />
+        </div>
+        <h3 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
+          {t('app.book.clippings.empty.title')}
+        </h3>
+        <p className="max-w-sm text-sm text-slate-500 dark:text-slate-400">
+          {t('app.book.clippings.empty.description')}
+        </p>
+      </div>
+    )
+  }
+
+  const footerState: 'loading' | 'hasMore' | 'end' = loadingMore
+    ? 'loading'
+    : hasMore
+      ? 'hasMore'
+      : 'end'
+
+  const columnCount = view === 'list' ? 1 : masonaryColumnCount
+  const columnGutter = view === 'list' ? 0 : 24
+
   return (
-    <Masonry
-      items={(clippingsData?.book.clippings ?? []) as Clipping[]}
-      columnCount={masonaryColumnCount}
-      columnGutter={30}
-      onRender={maybeLoadMore}
-      render={(row) => {
-        const clipping = row.data
-        return (
-          <ClippingItem
-            item={clipping}
-            domain={domain}
-            book={bookData}
-            key={clipping.id}
-            inAppChannel={IN_APP_CHANNEL.clippingFromBook}
-          />
-        )
-      }}
-    />
+    <section aria-label="clippings" className="mt-2">
+      <BookClippingsToolbar
+        totalCount={totalCount}
+        loadedCount={mergedItems.length}
+        sort={sort}
+        onSortChange={setSort}
+        view={view}
+        onViewChange={setView}
+      />
+
+      <Masonry
+        // Keying on view/sort forces Masonic to recalc layout cleanly.
+        key={`${view}-${sort}-${columnCount}`}
+        items={renderList}
+        columnCount={columnCount}
+        columnGutter={columnGutter}
+        onRender={maybeLoadMore}
+        itemKey={(item: BookClippingsItem) => item.id}
+        render={(row) => {
+          const clipping = row.data as BookClippingsItem
+          return (
+            <BookClippingCard
+              item={clipping}
+              domain={domain}
+              density={view === 'list' ? 'compact' : 'default'}
+              inAppChannel={IN_APP_CHANNEL.clippingFromBook}
+            />
+          )
+        }}
+      />
+
+      <InfiniteScrollFooter state={footerState} onLoadMore={loadMore} />
+    </section>
   )
 }
 

--- a/src/app/dash/[userid]/book/[bookid]/page.tsx
+++ b/src/app/dash/[userid]/book/[bookid]/page.tsx
@@ -21,7 +21,7 @@ import {
   wenquRequest,
 } from '@/services/wenqu'
 
-import BookPageContent from './content'
+import BookPageContent, { BOOK_CLIPPINGS_PAGE_SIZE } from './content'
 
 type PageProps = {
   params: Promise<{ bookid: string; userid: string }>
@@ -71,8 +71,7 @@ async function Page(props: PageProps) {
       variables: {
         id: ~~dbId,
         pagination: {
-          limit: 10,
-          offset: 0,
+          limit: BOOK_CLIPPINGS_PAGE_SIZE,
         },
       },
       context: {

--- a/src/app/dash/[userid]/book/[bookid]/skeleton.tsx
+++ b/src/app/dash/[userid]/book/[bookid]/skeleton.tsx
@@ -89,15 +89,30 @@ function BookPageSkeleton() {
         />
       </div>
 
+      {/* Toolbar skeleton */}
+      <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+        <div className="h-6 w-40 rounded-md bg-gray-200 dark:bg-zinc-700" />
+        <div className="flex items-center gap-2">
+          <div className="h-9 w-32 rounded-xl bg-gray-200 dark:bg-zinc-700" />
+          <div className="h-9 w-20 rounded-xl bg-gray-200 dark:bg-zinc-700" />
+        </div>
+      </div>
+
       {/* Clippings grid skeleton */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {new Array(6).fill(1).map((_, i) => (
           <div
             key={i}
-            className="space-y-4 rounded-2xl border border-slate-100/50 bg-slate-50/80 p-6 backdrop-blur-sm dark:border-slate-700/50 dark:bg-slate-800/70"
+            className="relative space-y-4 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/70 p-6 backdrop-blur-sm dark:border-slate-700/50 dark:bg-slate-800/60"
           >
-            <div className="h-6 w-3/4 rounded bg-gray-200 dark:bg-zinc-700" />
-            <div className="h-px w-full bg-gradient-to-r from-transparent via-gray-200 to-transparent dark:via-zinc-700" />
+            <span
+              aria-hidden
+              className="absolute top-4 bottom-4 left-0 w-[3px] rounded-r-full bg-gradient-to-b from-blue-300/40 to-transparent dark:from-blue-400/40"
+            />
+            <div className="flex items-center justify-between">
+              <div className="h-5 w-14 rounded-full bg-blue-100 dark:bg-blue-400/20" />
+              <div className="h-3 w-20 rounded bg-gray-200 dark:bg-zinc-700" />
+            </div>
             <div className="space-y-2">
               <div className="h-4 w-full rounded bg-gray-200 dark:bg-zinc-700" />
               <div className="h-4 w-5/6 rounded bg-gray-200 dark:bg-zinc-700" />

--- a/src/components/clipping-item/book-clipping-card.tsx
+++ b/src/components/clipping-item/book-clipping-card.tsx
@@ -1,0 +1,97 @@
+import dayjs from 'dayjs'
+import Link from 'next/link'
+
+import { useTranslation } from '@/i18n/client'
+import type { Clipping } from '@/schema/generated'
+import type { IN_APP_CHANNEL } from '@/services/channel'
+
+import ClippingContent from '../clipping-content'
+
+type BookClippingCardProps = {
+  item: Pick<Clipping, 'id' | 'content' | 'pageAt' | 'createdAt'>
+  domain: string
+  density?: 'default' | 'compact'
+  inAppChannel: IN_APP_CHANNEL
+  className?: string
+}
+
+function BookClippingCard(props: BookClippingCardProps) {
+  const {
+    item,
+    domain,
+    density = 'default',
+    inAppChannel,
+    className = '',
+  } = props
+  const { t } = useTranslation(undefined, 'book')
+
+  const pageLabel = item.pageAt ? String(item.pageAt).trim() : ''
+  const hasPage = pageLabel.length > 0
+  const date = item.createdAt ? dayjs(item.createdAt).format('YYYY-MM-DD') : ''
+
+  const isCompact = density === 'compact'
+
+  return (
+    <Link
+      href={`/dash/${domain}/clippings/${item.id}?iac=${inAppChannel}`}
+      className={`group relative mb-5 block ${className}`}
+    >
+      <article
+        className={[
+          'relative overflow-hidden rounded-2xl border backdrop-blur-xl transition-all duration-300 ease-out',
+          'border-slate-200/60 bg-white/70 shadow-[0_4px_24px_rgba(15,23,42,0.04)]',
+          'hover:-translate-y-0.5 hover:border-blue-300/60 hover:shadow-[0_12px_40px_rgba(59,130,246,0.15)]',
+          'dark:border-slate-700/50 dark:bg-slate-800/60 dark:shadow-[0_4px_24px_rgba(0,0,0,0.25)]',
+          'dark:hover:border-blue-400/40 dark:hover:shadow-[0_12px_40px_rgba(59,130,246,0.2)]',
+          'motion-reduce:transition-none motion-reduce:hover:translate-y-0',
+          isCompact ? 'p-4 lg:p-5' : 'p-6 lg:p-7',
+        ].join(' ')}
+      >
+        {/* Subtle left quote accent bar */}
+        {!isCompact && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute top-4 bottom-4 left-0 w-[3px] rounded-r-full bg-gradient-to-b from-blue-400/70 via-blue-400/40 to-transparent opacity-70 transition-opacity duration-300 group-hover:opacity-100 dark:from-blue-400/80 dark:via-blue-400/40"
+          />
+        )}
+
+        {/* Top row: page pill + date */}
+        {(hasPage || date) && (
+          <header
+            className={`flex items-center justify-between gap-2 ${isCompact ? 'mb-2' : 'mb-3'}`}
+          >
+            {hasPage ? (
+              <span className="inline-flex items-center rounded-full border border-blue-200/60 bg-blue-50/70 px-2.5 py-0.5 font-mono text-[11px] font-medium tracking-wide text-blue-600 dark:border-blue-400/30 dark:bg-blue-400/10 dark:text-blue-300">
+                {t('app.book.clippings.meta.page', { page: pageLabel })}
+              </span>
+            ) : (
+              <span />
+            )}
+            {date && (
+              <time
+                dateTime={item.createdAt as unknown as string}
+                className="text-[11px] font-medium tracking-wide text-slate-400 tabular-nums dark:text-slate-500"
+              >
+                {date}
+              </time>
+            )}
+          </header>
+        )}
+
+        {/* Body */}
+        <ClippingContent
+          content={item.content}
+          maxLines={isCompact ? 4 : 0}
+          className={[
+            'font-lxgw text-slate-800 dark:text-slate-200',
+            isCompact
+              ? 'text-base leading-relaxed lg:text-lg'
+              : 'text-lg leading-relaxed lg:text-xl',
+          ].join(' ')}
+        />
+      </article>
+    </Link>
+  )
+}
+
+export default BookClippingCard

--- a/src/components/clipping-item/book-clippings-toolbar.tsx
+++ b/src/components/clipping-item/book-clippings-toolbar.tsx
@@ -1,0 +1,124 @@
+import {
+  ArrowDownNarrowWide,
+  ArrowUpWideNarrow,
+  LayoutGrid,
+  List as ListIcon,
+} from 'lucide-react'
+
+import { useTranslation } from '@/i18n/client'
+
+export type ClippingsSortOrder = 'newest' | 'oldest'
+export type ClippingsViewMode = 'masonry' | 'list'
+
+type BookClippingsToolbarProps = {
+  totalCount: number
+  loadedCount: number
+  sort: ClippingsSortOrder
+  onSortChange: (next: ClippingsSortOrder) => void
+  view: ClippingsViewMode
+  onViewChange: (next: ClippingsViewMode) => void
+}
+
+const baseSegButton =
+  'flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all duration-200 focus:ring-2 focus:ring-blue-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50'
+
+function BookClippingsToolbar(props: BookClippingsToolbarProps) {
+  const { totalCount, loadedCount, sort, onSortChange, view, onViewChange } =
+    props
+  const { t } = useTranslation(undefined, 'book')
+
+  return (
+    <div className="mb-6 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+      {/* Summary */}
+      <div className="flex items-baseline gap-2">
+        <span className="text-base font-semibold text-slate-800 dark:text-slate-100">
+          {t('app.book.clippings.toolbar.count', { count: totalCount })}
+        </span>
+        {loadedCount > 0 && loadedCount < totalCount && (
+          <span className="text-xs text-slate-400 tabular-nums dark:text-slate-500">
+            · {loadedCount}/{totalCount}
+          </span>
+        )}
+      </div>
+
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Sort segmented toggle */}
+        <div
+          role="group"
+          aria-label="Sort"
+          className="flex items-center gap-0.5 rounded-xl border border-slate-200/70 bg-white/60 p-1 backdrop-blur-sm dark:border-slate-700/60 dark:bg-slate-800/50"
+        >
+          <button
+            type="button"
+            aria-pressed={sort === 'newest'}
+            onClick={() => onSortChange('newest')}
+            className={`${baseSegButton} ${
+              sort === 'newest'
+                ? 'bg-blue-400 text-white shadow-sm'
+                : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100'
+            }`}
+          >
+            <ArrowDownNarrowWide size={14} />
+            <span className="hidden sm:inline">
+              {t('app.book.clippings.toolbar.sort.newest')}
+            </span>
+          </button>
+          <button
+            type="button"
+            aria-pressed={sort === 'oldest'}
+            onClick={() => onSortChange('oldest')}
+            className={`${baseSegButton} ${
+              sort === 'oldest'
+                ? 'bg-blue-400 text-white shadow-sm'
+                : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100'
+            }`}
+          >
+            <ArrowUpWideNarrow size={14} />
+            <span className="hidden sm:inline">
+              {t('app.book.clippings.toolbar.sort.oldest')}
+            </span>
+          </button>
+        </div>
+
+        {/* View mode toggle */}
+        <div
+          role="group"
+          aria-label="View"
+          className="flex items-center gap-0.5 rounded-xl border border-slate-200/70 bg-white/60 p-1 backdrop-blur-sm dark:border-slate-700/60 dark:bg-slate-800/50"
+        >
+          <button
+            type="button"
+            aria-label={t('app.book.clippings.toolbar.view.masonry')}
+            title={t('app.book.clippings.toolbar.view.masonry')}
+            aria-pressed={view === 'masonry'}
+            onClick={() => onViewChange('masonry')}
+            className={`${baseSegButton} ${
+              view === 'masonry'
+                ? 'bg-blue-400 text-white shadow-sm'
+                : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100'
+            }`}
+          >
+            <LayoutGrid size={14} />
+          </button>
+          <button
+            type="button"
+            aria-label={t('app.book.clippings.toolbar.view.list')}
+            title={t('app.book.clippings.toolbar.view.list')}
+            aria-pressed={view === 'list'}
+            onClick={() => onViewChange('list')}
+            className={`${baseSegButton} ${
+              view === 'list'
+                ? 'bg-blue-400 text-white shadow-sm'
+                : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100'
+            }`}
+          >
+            <ListIcon size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BookClippingsToolbar

--- a/src/components/clipping-item/infinite-scroll-footer.tsx
+++ b/src/components/clipping-item/infinite-scroll-footer.tsx
@@ -1,0 +1,48 @@
+import { Loader2 } from 'lucide-react'
+
+import { useTranslation } from '@/i18n/client'
+
+type InfiniteScrollFooterProps = {
+  state: 'loading' | 'hasMore' | 'end'
+  onLoadMore?: () => void
+}
+
+function InfiniteScrollFooter(props: InfiniteScrollFooterProps) {
+  const { state, onLoadMore } = props
+  const { t } = useTranslation(undefined, 'book')
+
+  if (state === 'loading') {
+    return (
+      <div className="mt-2 flex items-center justify-center gap-2 py-8 text-sm text-slate-500 dark:text-slate-400">
+        <Loader2 size={16} className="animate-spin text-blue-400" />
+        <span>{t('app.book.clippings.loading')}</span>
+      </div>
+    )
+  }
+
+  if (state === 'hasMore') {
+    return (
+      <div className="mt-2 flex justify-center py-8">
+        <button
+          type="button"
+          onClick={onLoadMore}
+          className="rounded-xl border border-blue-200/60 bg-white/70 px-5 py-2 text-sm font-medium text-blue-500 shadow-sm backdrop-blur-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600 focus:ring-2 focus:ring-blue-400 focus:outline-none dark:border-blue-400/30 dark:bg-slate-800/60 dark:text-blue-300 dark:hover:border-blue-400/60 dark:hover:bg-blue-400/10 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+        >
+          {t('app.book.clippings.loadMore')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-2 flex items-center gap-4 py-8">
+      <div className="h-px flex-grow bg-gradient-to-r from-transparent via-slate-200 to-transparent dark:via-slate-700" />
+      <span className="text-xs font-medium tracking-wide text-slate-400 uppercase dark:text-slate-500">
+        {t('app.book.clippings.end')}
+      </span>
+      <div className="h-px flex-grow bg-gradient-to-r from-transparent via-slate-200 to-transparent dark:via-slate-700" />
+    </div>
+  )
+}
+
+export default InfiniteScrollFooter

--- a/src/locales/en/book.json
+++ b/src/locales/en/book.json
@@ -21,6 +21,30 @@
         "title": "Summary",
         "showMore": "Show more",
         "showLess": "Show less"
+      },
+      "clippings": {
+        "toolbar": {
+          "count": "{{count}} clipping",
+          "count_plural": "{{count}} clippings",
+          "sort": {
+            "newest": "Newest",
+            "oldest": "Oldest"
+          },
+          "view": {
+            "masonry": "Masonry",
+            "list": "List"
+          }
+        },
+        "loadMore": "Load more",
+        "loading": "Loading more…",
+        "end": "You've reached the end",
+        "empty": {
+          "title": "No clippings yet",
+          "description": "Clippings from this book will appear here."
+        },
+        "meta": {
+          "page": "p. {{page}}"
+        }
       }
     }
   }

--- a/src/locales/ko/book.json
+++ b/src/locales/ko/book.json
@@ -21,6 +21,30 @@
         "title": "요약",
         "showMore": "열기",
         "showLess": "닫기"
+      },
+      "clippings": {
+        "toolbar": {
+          "count": "{{count}}개의 클리핑",
+          "count_plural": "{{count}}개의 클리핑",
+          "sort": {
+            "newest": "최신순",
+            "oldest": "오래된순"
+          },
+          "view": {
+            "masonry": "메이슨리",
+            "list": "목록"
+          }
+        },
+        "loadMore": "더 불러오기",
+        "loading": "불러오는 중…",
+        "end": "마지막 클리핑입니다",
+        "empty": {
+          "title": "아직 클리핑이 없습니다",
+          "description": "이 책의 클리핑이 여기에 표시됩니다."
+        },
+        "meta": {
+          "page": "{{page}}쪽"
+        }
       }
     }
   }

--- a/src/locales/zhCN/book.json
+++ b/src/locales/zhCN/book.json
@@ -21,6 +21,30 @@
         "title": "摘要",
         "showMore": "展开",
         "showLess": "闭合"
+      },
+      "clippings": {
+        "toolbar": {
+          "count": "{{count}} 条摘录",
+          "count_plural": "{{count}} 条摘录",
+          "sort": {
+            "newest": "最新",
+            "oldest": "最早"
+          },
+          "view": {
+            "masonry": "瀑布流",
+            "list": "列表"
+          }
+        },
+        "loadMore": "加载更多",
+        "loading": "加载中…",
+        "end": "已经到底啦",
+        "empty": {
+          "title": "还没有摘录",
+          "description": "这本书的摘录会出现在这里。"
+        },
+        "meta": {
+          "page": "第 {{page}} 页"
+        }
       }
     }
   }

--- a/src/schema/book.graphql
+++ b/src/schema/book.graphql
@@ -1,4 +1,4 @@
-query book($id: Int!, $pagination: PaginationLegacy!) {
+query book($id: Int!, $pagination: Pagination!) {
   book(id: $id, pagination: $pagination) {
     doubanId
     startReadingAt


### PR DESCRIPTION
## Summary
Refactored the book clippings display to provide users with better control over how they browse clippings. Added client-side sorting (newest/oldest), view mode toggle (masonry/list), improved pagination with cursor-based loading, and a dedicated toolbar with visual feedback.

## Key Changes

- **New Components**:
  - `BookClippingsToolbar`: Segmented controls for sort order and view mode with clipping count display
  - `BookClippingCard`: Refactored clipping display with density modes (default/compact) and improved styling
  - `InfiniteScrollFooter`: Loading states and end-of-list indicator with manual load-more button

- **Pagination Improvements**:
  - Switched from offset-based to cursor-based pagination (using `lastId`)
  - Changed page size constant to `BOOK_CLIPPINGS_PAGE_SIZE = 12`
  - Implemented proper deduplication of merged items using `uniqueById` utility
  - Added loading state management with `loadingRef` and `loadingMore` state

- **Sorting & Filtering**:
  - Client-side sorting by clipping ID (newest/oldest) with instant UI response
  - Merged and deduplicated server-fetched and extra-loaded items
  - Memoized render list to prevent unnecessary re-sorts

- **View Modes**:
  - Masonry layout (default, responsive columns)
  - List layout (single column, compact density)
  - Dynamic column gutter adjustment based on view mode

- **UX Enhancements**:
  - Empty state with icon and localized messaging
  - Improved loading indicators and footer states
  - Better visual hierarchy with toolbar summary showing loaded/total counts
  - Refined card styling with hover effects and dark mode support

- **Localization**:
  - Added translation keys for toolbar, loading states, empty state, and metadata (page numbers)
  - Supported in English, Korean, and Simplified Chinese

- **Schema Updates**:
  - Updated GraphQL query to use `Pagination` instead of `PaginationLegacy`
  - Exported `BOOK_CLIPPINGS_PAGE_SIZE` from content component for server-side initial query

- **Skeleton Updates**:
  - Enhanced loading skeleton to match new toolbar and card layouts

https://claude.ai/code/session_011YmdsaXCz6KAWRPrfeFWL1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/clippingkk/web/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
