### PR TITLE
fix(auth): recover from invalid sessions

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from 'next/server'
+
+import { COOKIE_TOKEN_KEY, USER_ID_KEY } from './constants/storage'
+import { proxy } from './proxy'
+
+test('clears stale authentication cookies before rendering the login page', () => {
+  const request = new NextRequest(
+    'https://clippingkk.example/auth/auth-v4?clean=true',
+    {
+      headers: {
+        cookie: `${COOKIE_TOKEN_KEY}=stale-token; ${USER_ID_KEY}=1`,
+      },
+    }
+  )
+
+  const response = proxy(request)
+  const setCookie = response.headers.get('set-cookie') ?? ''
+
+  expect(response.status).toBe(200)
+  expect(setCookie).toContain(`${COOKIE_TOKEN_KEY}=;`)
+  expect(setCookie).toContain(`${USER_ID_KEY}=;`)
+})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,15 @@ export function proxy(request: NextRequest) {
     return NextResponse.next()
   }
 
+  if (!url.pathname.includes('callback') && url.searchParams.has('clean')) {
+    request.cookies.delete(COOKIE_TOKEN_KEY)
+    request.cookies.delete(USER_ID_KEY)
+    const response = NextResponse.next()
+    response.cookies.delete(COOKIE_TOKEN_KEY)
+    response.cookies.delete(USER_ID_KEY)
+    return response
+  }
+
   if (!request.cookies.has(COOKIE_TOKEN_KEY)) {
     return NextResponse.next()
   }
@@ -17,15 +26,6 @@ export function proxy(request: NextRequest) {
   // If going to the authentication page but already having a token and UID, just redirect to my home page.
   const uid = request.cookies.get(USER_ID_KEY)?.value
   if (!uid) {
-    return NextResponse.next()
-  }
-  if (
-    uid &&
-    !url.pathname.includes('callback') &&
-    url.searchParams.has('clean')
-  ) {
-    request.cookies.delete(COOKIE_TOKEN_KEY)
-    request.cookies.delete(USER_ID_KEY)
     return NextResponse.next()
   }
   const nextUrl = new URL(`/dash/${uid}/home`, request.url)

--- a/src/server/__tests__/auth.test.ts
+++ b/src/server/__tests__/auth.test.ts
@@ -1,3 +1,4 @@
+import { optionalUserId } from '../auth'
 import { resetServerEnvForTests } from '../env'
 import { decodeLegacyValue, encodeLegacyValue } from '../legacy-crypto'
 
@@ -15,4 +16,16 @@ test('round trips legacy AES-CFB values used by X-CLI and WeChat binding', async
 
   expect(encrypted).not.toContain('legacy-token-value')
   await expect(decodeLegacyValue(encrypted)).resolves.toBe('legacy-token-value')
+})
+
+test('normalizes invalid bearer tokens as unauthorized', async () => {
+  const request = new Request('https://clippingkk.example/api/v2/graphql', {
+    headers: { Authorization: 'Bearer invalid-token' },
+  })
+
+  await expect(optionalUserId(request)).rejects.toMatchObject({
+    message: 'invalid token',
+    status: 401,
+    code: 'UNAUTHORIZED',
+  })
 })

--- a/src/server/__tests__/graphql-context.test.ts
+++ b/src/server/__tests__/graphql-context.test.ts
@@ -1,0 +1,19 @@
+import type { YogaInitialContext } from 'graphql-yoga'
+
+import { createGraphQLContext } from '../graphql/context'
+
+test('exposes authentication failures as unauthorized GraphQL errors', async () => {
+  const request = new Request('https://clippingkk.example/api/v2/graphql', {
+    headers: { Authorization: 'Bearer invalid-token' },
+  })
+
+  await expect(
+    createGraphQLContext({ request } as YogaInitialContext)
+  ).rejects.toMatchObject({
+    message: 'invalid token',
+    extensions: {
+      code: 'UNAUTHORIZED',
+      http: { status: 401 },
+    },
+  })
+})

--- a/src/server/__tests__/resolvers.test.ts
+++ b/src/server/__tests__/resolvers.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import type { Clipping } from '../db/schema'
+import { resolvers } from '../graphql/resolvers'
+
+test('treats legacy null clipping nouns as an empty list', async () => {
+  const clipping = {
+    content: 'A legacy clipping',
+    nouns: null,
+  } as unknown as Clipping
+
+  await expect(resolvers.Clipping.richContent(clipping)).resolves.toEqual({
+    html: 'A legacy clipping',
+    plain: 'A legacy clipping',
+    segments: ['A legacy clipping'],
+    nouns: [],
+  })
+})

--- a/src/server/__tests__/resolvers.test.ts
+++ b/src/server/__tests__/resolvers.test.ts
@@ -1,7 +1,18 @@
 // @vitest-environment node
 
-import type { Clipping } from '../db/schema'
+import { orders, type Clipping, type User } from '../db/schema'
+import type { GraphQLContext } from '../graphql/context'
 import { resolvers } from '../graphql/resolvers'
+
+const { getDatabaseMock } = vi.hoisted(() => ({
+  getDatabaseMock: vi.fn(),
+}))
+
+vi.mock('../db', () => ({ getDatabase: getDatabaseMock }))
+
+beforeEach(() => {
+  getDatabaseMock.mockReset()
+})
 
 test('treats legacy null clipping nouns as an empty list', async () => {
   const clipping = {
@@ -14,5 +25,48 @@ test('treats legacy null clipping nouns as an empty list', async () => {
     plain: 'A legacy clipping',
     segments: ['A legacy clipping'],
     nouns: [],
+  })
+})
+
+test('selects only legacy-compatible fields for a user order list', async () => {
+  const order = {
+    id: 9,
+    orderId: 'order_9',
+    sku: 'premium',
+    subscriptionId: 'subscription_9',
+    orderCreatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    amount: 999,
+    currency: 'usd',
+  }
+  const orderBy = vi.fn().mockResolvedValue([order])
+  const where = vi.fn(() => ({ orderBy }))
+  const from = vi.fn(() => ({ where }))
+  const select = vi.fn((fields: Record<string, unknown>) => {
+    expect(fields).not.toHaveProperty('createdAt')
+    expect(fields).not.toHaveProperty('updatedAt')
+    return { from }
+  })
+  getDatabaseMock.mockReturnValue({ db: { select } })
+
+  await expect(
+    resolvers.User.orderList({ id: 2 } as User, {}, {
+      userId: 2,
+    } as GraphQLContext)
+  ).resolves.toEqual([
+    {
+      id: 'subscription_9',
+      subscriptionId: 'subscription_9',
+      status: 'active',
+      orders: [order],
+    },
+  ])
+  expect(select).toHaveBeenCalledWith({
+    id: orders.id,
+    orderId: orders.orderId,
+    sku: orders.sku,
+    subscriptionId: orders.subscriptionId,
+    orderCreatedAt: orders.orderCreatedAt,
+    amount: orders.amount,
+    currency: orders.currency,
   })
 })

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -98,11 +98,7 @@ export async function optionalUserId(request: Request) {
     return await verifyToken(token)
   } catch (error) {
     if (error instanceof ApiError) throw error
-    throw new ApiError(
-      error instanceof Error ? error.message : 'invalid token',
-      401,
-      'UNAUTHORIZED'
-    )
+    throw new ApiError('invalid token', 401, 'UNAUTHORIZED')
   }
 }
 

--- a/src/server/graphql/context.ts
+++ b/src/server/graphql/context.ts
@@ -1,6 +1,8 @@
+import { GraphQLError } from 'graphql'
 import type { YogaInitialContext } from 'graphql-yoga'
 
 import { optionalUserId } from '../auth'
+import { ApiError } from '../errors'
 
 export type GraphQLContext = {
   request: Request
@@ -17,10 +19,21 @@ export async function createGraphQLContext(
     request.headers.get('x-accept-language') ??
     request.headers.get('accept-language') ??
     'en'
-  return {
-    request,
-    userId: await optionalUserId(request),
-    ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? '',
-    language: language.split(',')[0],
+  try {
+    return {
+      request,
+      userId: await optionalUserId(request),
+      ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? '',
+      language: language.split(',')[0],
+    }
+  } catch (error) {
+    if (!(error instanceof ApiError)) throw error
+    throw new GraphQLError(error.message, {
+      originalError: error,
+      extensions: {
+        code: error.code,
+        http: { status: error.status },
+      },
+    })
   }
 }

--- a/src/server/graphql/resolvers.ts
+++ b/src/server/graphql/resolvers.ts
@@ -1678,11 +1678,9 @@ export const resolvers: Record<string, Record<string, any>> = {
     source: (clipping: Clipping) => sourceToEnum(clipping.source),
     creator: (clipping: Clipping) => userById(clipping.createdBy),
     richContent: async (clipping: Clipping) => {
-      const nounRows = clipping.nouns.length
-        ? await db()
-            .select()
-            .from(nouns)
-            .where(inArray(nouns.id, clipping.nouns))
+      const nounIds = Array.isArray(clipping.nouns) ? clipping.nouns : []
+      const nounRows = nounIds.length
+        ? await db().select().from(nouns).where(inArray(nouns.id, nounIds))
         : []
       const activeNouns = nounRows.filter((noun) => noun.scope !== 3)
       const pattern = activeNouns

--- a/src/server/graphql/resolvers.ts
+++ b/src/server/graphql/resolvers.ts
@@ -1421,7 +1421,15 @@ export const resolvers: Record<string, Record<string, any>> = {
     orderList: async (user: User, _args: Args, context: GraphQLContext) => {
       if (context.userId !== user.id) return []
       const rows = await db()
-        .select()
+        .select({
+          id: orders.id,
+          orderId: orders.orderId,
+          sku: orders.sku,
+          subscriptionId: orders.subscriptionId,
+          orderCreatedAt: orders.orderCreatedAt,
+          amount: orders.amount,
+          currency: orders.currency,
+        })
         .from(orders)
         .where(eq(orders.userOrders, user.id))
         .orderBy(desc(orders.id))

--- a/src/services/__tests__/ajax.test.ts
+++ b/src/services/__tests__/ajax.test.ts
@@ -1,6 +1,12 @@
+import { CombinedGraphQLErrors } from '@apollo/client'
 import toast from 'react-hot-toast'
 
-import { request, requestJson, updateToken } from '@/services/ajax'
+import {
+  isUnauthorizedApolloError,
+  request,
+  requestJson,
+  updateToken,
+} from '@/services/ajax'
 
 vi.mock('react-hot-toast', () => ({
   default: {
@@ -89,5 +95,18 @@ describe('HTTP client helpers', () => {
 
     await expect(request('/v2/example')).rejects.toThrow('not allowed')
     expect(toast.error).toHaveBeenCalledOnce()
+  })
+
+  it('recognizes unauthorized GraphQL errors', () => {
+    const error = new CombinedGraphQLErrors({
+      errors: [
+        {
+          message: 'invalid token',
+          extensions: { code: 'UNAUTHORIZED' },
+        },
+      ],
+    })
+
+    expect(isUnauthorizedApolloError(error)).toBe(true)
   })
 })

--- a/src/services/ajax.ts
+++ b/src/services/ajax.ts
@@ -129,19 +129,28 @@ export const authLink = new ApolloLink((operation, forward) => {
   return forward(operation)
 })
 
+export function isUnauthorizedApolloError(error: unknown) {
+  if (error instanceof ServerError) return error.statusCode === 401
+  return (
+    CombinedGraphQLErrors.is(error) &&
+    error.errors.some(
+      (graphQLError) => graphQLError.extensions?.code === 'UNAUTHORIZED'
+    )
+  )
+}
+
 const errorLink = onError(({ error }) => {
-  if (CombinedGraphQLErrors.is(error)) {
+  if (isUnauthorizedApolloError(error)) {
+    if (typeof window !== 'undefined') {
+      updateToken('')
+      profile.onLogout()
+    }
+  } else if (CombinedGraphQLErrors.is(error)) {
     if (typeof window !== 'undefined') {
       toast.error(error.errors[0].message)
     }
   } else if (error instanceof ServerError) {
     console.log(`[Network error]: ${error}`)
-    if (typeof window !== 'undefined') {
-      if (error.statusCode === 401) {
-        updateToken('')
-        profile.onLogout()
-      }
-    }
   }
 })
 

--- a/src/services/apollo.server.ts
+++ b/src/services/apollo.server.ts
@@ -1,7 +1,6 @@
 import {
   ApolloLink,
   HttpLink,
-  ServerError,
   type OperationVariables,
   type QueryOptions,
 } from '@apollo/client'
@@ -15,7 +14,7 @@ import { redirect } from 'next/navigation'
 import { API_HOST } from '@/constants/config'
 import { getServerEnv } from '@/server/env'
 
-import { authLink } from './ajax'
+import { authLink, isUnauthorizedApolloError } from './ajax'
 import { apolloCacheConfig } from './apollo.shard'
 
 export function getApolloServerGraphqlUrl() {
@@ -41,11 +40,8 @@ export function doApolloServerQuery<
     .query(options)
     .then((result) => ({ data: result.data as TData }))
     .catch((e: any) => {
-      if (e instanceof ServerError) {
-        const statusCode = e.statusCode
-        if (statusCode === 401) {
-          return redirect('/auth/auth-v4?clean=true')
-        }
+      if (isUnauthorizedApolloError(e)) {
+        return redirect('/auth/auth-v4?clean=true')
       }
       throw e
     })


### PR DESCRIPTION
## Summary

- normalize invalid JWT failures as `UNAUTHORIZED` GraphQL responses
- recognize unauthorized Apollo errors during SSR and browser requests
- redirect stale dashboard sessions to login and expire both auth cookies
- add coverage for JWT normalization, GraphQL context errors, Apollo classification, and cookie cleanup

## Root cause

JWT verification failures were returned as valid GraphQL error payloads, so Apollo wrapped them in `CombinedGraphQLErrors`. The server-side client only handled `ServerError` status codes and let the combined error crash dashboard rendering. The login cleanup path also removed cookies from the request without expiring them in the response.

## Impact

Users with tokens signed by an old or different `JWT_SECRET` are redirected to login with their stale session cleared instead of seeing a dashboard error boundary.

## Validation

- `pnpm test`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- invalid-token GraphQL request returns HTTP 401 with `UNAUTHORIZED`
- stale dashboard request emits the App Router login redirect
- login cleanup returns HTTP 200 and expires `ck-token` and `ck-uid`
