### PR TITLE
fix(deploy): defer server env validation to runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@ README.md
 .next
 .git
 .unikraft
+.env
+.env.*
+!.env.example

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -42,6 +42,11 @@ issued tokens. Use distinct Redis databases for cache and queue data. Configure
 optional authentication, payment, email, object-storage, and observability
 integrations from `.env.example` only when those features are enabled.
 
+The application validates its server environment before accepting requests. A
+missing or invalid `DATABASE_URL`, `REDIS_URL`, or `JWT_SECRET` causes the
+container to exit during startup. This validation does not connect to
+PostgreSQL or Redis; use `/probe` to verify service connectivity.
+
 `NEXT_PUBLIC_*` values are embedded into browser assets during the image build.
 They are not runtime secrets and changing them requires a new image. The
 published image already contains its release-time values.
@@ -120,7 +125,8 @@ docker build \
 
 Pass only public build values as build arguments. Supply database credentials,
 JWT keys, and integration secrets at runtime through `--env-file` or a secret
-manager.
+manager. Docker excludes `.env` files from the build context so server secrets
+are neither loaded by `next build` nor copied into the standalone image.
 
 ## Upgrade and rollback
 

--- a/src/app/api/rss/user/[uid]/clippings/route.test.ts
+++ b/src/app/api/rss/user/[uid]/clippings/route.test.ts
@@ -1,0 +1,24 @@
+const { connection } = vi.hoisted(() => ({
+  connection: vi.fn<() => Promise<void>>(),
+}))
+
+vi.mock('next/server', () => ({ connection }))
+
+import { GET } from './route'
+
+beforeEach(() => {
+  connection.mockResolvedValue()
+})
+
+test('defers RSS generation to request time', async () => {
+  const params = Promise.resolve().then(() => {
+    expect(connection).toHaveBeenCalledOnce()
+    return { uid: '0' }
+  })
+
+  await expect(
+    GET(new Request('https://clippingkk.example/api/rss/user/0/clippings'), {
+      params,
+    })
+  ).rejects.toMatchObject({ message: 'user id not found' })
+})

--- a/src/app/api/rss/user/[uid]/clippings/route.ts
+++ b/src/app/api/rss/user/[uid]/clippings/route.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, isNull } from 'drizzle-orm'
+import { connection } from 'next/server'
 
 import { getDatabase } from '@/server/db'
 import { clippings, users } from '@/server/db/schema'
@@ -18,6 +19,7 @@ export async function GET(
   _request: Request,
   context: { params: Promise<{ uid: string }> }
 ) {
+  await connection()
   const uid = Number((await context.params).uid)
   if (!Number.isInteger(uid) || uid <= 0)
     throw new ApiError('user id not found')

--- a/src/app/auth/public-data-prefetch.ts
+++ b/src/app/auth/public-data-prefetch.ts
@@ -11,7 +11,7 @@ export type PublicDataWithBooks = {
 }
 
 export async function fetchPublicDataWithBooks(): Promise<PublicDataWithBooks> {
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
   const data = await client.query<PublicDataQuery>({
     query: PublicDataDocument,
     variables: {

--- a/src/app/dash/[userid]/admin/page.tsx
+++ b/src/app/dash/[userid]/admin/page.tsx
@@ -31,7 +31,7 @@ async function AdminPanel(props: PageProps) {
 
   const offset = sp.offset ? ~~sp.offset : 0
 
-  const ac = getApolloServerClient()
+  const ac = await getApolloServerClient()
 
   const { data } = await ac.query<
     UncheckBooksQueryQuery,

--- a/src/app/dash/[userid]/clippings/[clippingid]/data.ts
+++ b/src/app/dash/[userid]/clippings/[clippingid]/data.ts
@@ -23,7 +23,7 @@ export const getClippingData = cache(async (clippingId: number) => {
   const cs = await cookies()
   const token = cs.get(COOKIE_TOKEN_KEY)?.value
   const uid = cs.get(USER_ID_KEY)?.value
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
 
   const clippingsResponse = await client.query<
     FetchClippingQuery,

--- a/src/app/dash/[userid]/clippings/[clippingid]/opengraph-image.tsx
+++ b/src/app/dash/[userid]/clippings/[clippingid]/opengraph-image.tsx
@@ -30,7 +30,7 @@ export default async function Image(req: {
 }) {
   const cid = ~~req.params.clippingid
 
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
   const clippingsResponse = await client.query<
     FetchClippingQuery,
     FetchClippingQueryVariables

--- a/src/app/dash/[userid]/settings/orders/page.tsx
+++ b/src/app/dash/[userid]/settings/orders/page.tsx
@@ -35,7 +35,7 @@ async function OrdersTable(props: Props) {
 
   const myUidInt = myUid ? parseInt(myUid, 10) : undefined
 
-  const apolloClient = getApolloServerClient()
+  const apolloClient = await getApolloServerClient()
 
   const uid = myUidInt
 

--- a/src/app/dash/[userid]/square/page.tsx
+++ b/src/app/dash/[userid]/square/page.tsx
@@ -18,7 +18,7 @@ import { isValidDoubanId, wenquBooksByIdsQueryOptions } from '@/services/wenqu'
 import SquarePageContent from './content'
 
 export async function generateMetadata(): Promise<Metadata> {
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
   const squareResponse = await client.query<
     FetchSquareDataQuery,
     FetchSquareDataQueryVariables

--- a/src/app/dash/[userid]/unchecked/page.tsx
+++ b/src/app/dash/[userid]/unchecked/page.tsx
@@ -26,7 +26,7 @@ async function UncheckedPage(props: Props) {
 
   const myUidInt = myUid ? parseInt(myUid, 10) : undefined
 
-  const apolloClient = getApolloServerClient()
+  const apolloClient = await getApolloServerClient()
   const { data: profileResponse } = await apolloClient.query<
     ProfileQuery,
     ProfileQueryVariables

--- a/src/app/dash/[userid]/upload/page.tsx
+++ b/src/app/dash/[userid]/upload/page.tsx
@@ -37,7 +37,7 @@ async function Page(props: Props) {
 
   const myUidInt = myUid ? parseInt(myUid, 10) : undefined
 
-  const apolloClient = getApolloServerClient()
+  const apolloClient = await getApolloServerClient()
   const { data: profileResponse } = await apolloClient.query<
     ProfileQuery,
     ProfileQueryVariables

--- a/src/app/probe/route.test.ts
+++ b/src/app/probe/route.test.ts
@@ -1,0 +1,30 @@
+const { connection, isDatabaseReady, isRedisReady } = vi.hoisted(() => ({
+  connection: vi.fn<() => Promise<void>>(),
+  isDatabaseReady: vi.fn<() => Promise<boolean>>(),
+  isRedisReady: vi.fn<() => Promise<boolean>>(),
+}))
+
+vi.mock('next/server', () => ({ connection }))
+vi.mock('@/server/db', () => ({ isDatabaseReady }))
+vi.mock('@/server/redis', () => ({ isRedisReady }))
+
+import { GET } from './route'
+
+beforeEach(() => {
+  connection.mockResolvedValue()
+  isDatabaseReady.mockResolvedValue(true)
+  isRedisReady.mockResolvedValue(true)
+})
+
+test('defers readiness checks to request time', async () => {
+  const response = await GET()
+
+  expect(connection).toHaveBeenCalledOnce()
+  expect(connection.mock.invocationCallOrder[0]).toBeLessThan(
+    isDatabaseReady.mock.invocationCallOrder[0]
+  )
+  expect(connection.mock.invocationCallOrder[0]).toBeLessThan(
+    isRedisReady.mock.invocationCallOrder[0]
+  )
+  expect(response.status).toBe(204)
+})

--- a/src/app/probe/route.ts
+++ b/src/app/probe/route.ts
@@ -1,7 +1,10 @@
+import { connection } from 'next/server'
+
 import { isDatabaseReady } from '@/server/db'
 import { isRedisReady } from '@/server/redis'
 
 export async function GET() {
+  await connection()
   const [database, redis] = await Promise.all([
     isDatabaseReady(),
     isRedisReady(),

--- a/src/app/report/yearly-legacy/page.tsx
+++ b/src/app/report/yearly-legacy/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata(
   const uid = ~~sp.uid
   const year = sp.year ? ~~sp.year : new Date().getFullYear()
 
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
   const reportInfoResponse = await client.query<
     FetchYearlyReportQuery,
     FetchYearlyReportQueryVariables
@@ -58,7 +58,7 @@ async function YearlyLegacyPage(props: YearlyLegacyPageProps) {
   const uid = ~~sp.uid
   const year = sp.year ? ~~sp.year : new Date().getFullYear()
 
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
   // const uid = ~~(context.params?.userid ?? -1) as number
   const reportInfoResponse = await client.query<
     FetchYearlyReportQuery,

--- a/src/app/report/yearly/page.tsx
+++ b/src/app/report/yearly/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata(
   const uid = ~~sp.uid
   const year = sp?.year ? ~~sp.year : new Date().getFullYear()
 
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
   const reportInfoResponse = await client.query<
     FetchYearlyReportQuery,
     FetchYearlyReportQueryVariables
@@ -59,7 +59,7 @@ async function YearlyPage(props: YearlyLegacyPageProps) {
   const year = sp.year ? ~~sp.year : new Date().getFullYear()
   // const uid = ~~(context.params?.userid ?? -1) as number
 
-  const client = getApolloServerClient()
+  const client = await getApolloServerClient()
   const reportInfoResponse = await client.query<
     FetchYearlyReportQuery,
     FetchYearlyReportQueryVariables

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -1,0 +1,55 @@
+import { resetServerEnvForTests } from '@/server/env'
+
+import { register } from './instrumentation'
+
+const originalEnv = { ...process.env }
+let exit: ReturnType<typeof vi.spyOn>
+let consoleError: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  exit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`)
+  })
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  process.env = { ...originalEnv, NEXT_RUNTIME: 'nodejs', RUN_WORKER: 'false' }
+  delete process.env.DATABASE_URL
+  delete process.env.REDIS_URL
+  delete process.env.JWT_SECRET
+  resetServerEnvForTests()
+})
+
+afterEach(() => {
+  exit.mockRestore()
+  consoleError.mockRestore()
+})
+
+afterAll(() => {
+  process.env = originalEnv
+  resetServerEnvForTests()
+})
+
+test('validates required server environment during Node.js startup', async () => {
+  await expect(register()).rejects.toThrow('process.exit(1)')
+
+  expect(exit).toHaveBeenCalledWith(1)
+  expect(consoleError).toHaveBeenCalledWith(
+    'Invalid server environment',
+    expect.objectContaining({
+      issues: expect.arrayContaining([
+        expect.objectContaining({ path: ['DATABASE_URL'] }),
+        expect.objectContaining({ path: ['REDIS_URL'] }),
+        expect.objectContaining({ path: ['JWT_SECRET'] }),
+      ]),
+    })
+  )
+})
+
+test('completes startup validation when required environment is valid', async () => {
+  process.env.DATABASE_URL =
+    'postgresql://postgres:admin@localhost:5432/clippingkk_test'
+  process.env.REDIS_URL = 'redis://localhost:6379/15'
+  process.env.JWT_SECRET = 'test-jwt-secret'
+  resetServerEnvForTests()
+
+  await expect(register()).resolves.toBeUndefined()
+})

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,9 +1,16 @@
 export async function register() {
-  if (
-    process.env.NEXT_RUNTIME !== 'nodejs' ||
-    process.env.RUN_WORKER !== 'true'
-  )
-    return
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return
+
+  const { getServerEnv } = await import('./server/env')
+  let env
+  try {
+    env = getServerEnv()
+  } catch (error) {
+    console.error('Invalid server environment', error)
+    process.exit(1)
+  }
+  if (!env.runWorker) return
+
   const { startWorker } = await import('./server/jobs/worker')
   startWorker()
 }

--- a/src/server/__tests__/http.test.ts
+++ b/src/server/__tests__/http.test.ts
@@ -2,7 +2,14 @@ import { resetServerEnvForTests } from '@/server/env'
 import { ApiError } from '@/server/errors'
 import { errorJson, json, route } from '@/server/http'
 
+const { connection } = vi.hoisted(() => ({
+  connection: vi.fn<() => Promise<void>>(),
+}))
+
+vi.mock('next/server', () => ({ connection }))
+
 beforeEach(() => {
+  connection.mockResolvedValue()
   process.env.DATABASE_URL =
     'postgresql://postgres:admin@localhost:5432/clippingkk_test'
   process.env.REDIS_URL = 'redis://localhost:6379/15'
@@ -12,6 +19,19 @@ beforeEach(() => {
 })
 
 describe('HTTP response helpers', () => {
+  it('defers route handlers to request time before executing them', async () => {
+    const handler = route(async () => {
+      expect(connection).toHaveBeenCalledOnce()
+      return json({ ok: true })
+    })
+
+    const response = await handler(
+      new Request('https://clippingkk.example/api/v2/config')
+    )
+
+    expect(response.status).toBe(200)
+  })
+
   it('builds the shared success envelope', async () => {
     const response = json({ ok: true }, 201, 'created')
 

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,3 +1,5 @@
+import { connection } from 'next/server'
+
 import type { ApiErrorResponse, ApiSuccessResponse } from '@/contracts/http'
 
 import { getServerEnv } from './env'
@@ -52,6 +54,7 @@ function withCors(response: Response, request: Request) {
 
 export function route(handler: Handler): Handler {
   return async (request, context) => {
+    await connection()
     try {
       return withCors(await handler(request, context), request)
     } catch (error) {

--- a/src/services/apollo.server.ts
+++ b/src/services/apollo.server.ts
@@ -10,6 +10,7 @@ import {
   registerApolloClient,
 } from '@apollo/client-integration-nextjs'
 import { redirect } from 'next/navigation'
+import { connection } from 'next/server'
 
 import { API_HOST } from '@/constants/config'
 import { getServerEnv } from '@/server/env'
@@ -30,13 +31,17 @@ const { getClient } = registerApolloClient(() => {
   })
 })
 
-export const getApolloServerClient = getClient
+export async function getApolloServerClient() {
+  await connection()
+  return getClient()
+}
 
-export function doApolloServerQuery<
+export async function doApolloServerQuery<
   TData,
   TVariables extends OperationVariables = OperationVariables,
 >(options: QueryOptions<TVariables, TData>): Promise<{ data: TData }> {
-  return getApolloServerClient()
+  const client = await getApolloServerClient()
+  return client
     .query(options)
     .then((result) => ({ data: result.data as TData }))
     .catch((e: any) => {


### PR DESCRIPTION
## Summary

- validate server-only environment variables when the Node.js server starts and exit on invalid configuration
- defer API handlers, readiness checks, RSS generation, and server-side Apollo access to request time
- exclude dotenv files from Docker builds and document the runtime configuration contract

## Root cause

With Cache Components enabled, GET handlers and server-rendered pages could execute while `next build` was prerendering. Those paths reached `getServerEnv()` before runtime variables existed, so validation errors or unhealthy responses could be baked into the build. The Docker context also included local dotenv files, which Next.js standalone output can copy into the final image.

## Impact

The same standalone image can now be promoted between environments. Server secrets are supplied at runtime, invalid configuration terminates the container, and readiness continues to check PostgreSQL and Redis connectivity separately.

## Validation

- `pnpm test` — 13 files and 29 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm typecheck:server`
- production Webpack build with database, Redis, queue, and JWT variables blank
- verified missing runtime variables exit with status 1
- verified `/api/v2/config` returns a runtime-injected `S3_HOST`
- all changed files pass `oxfmt --check`

Docker image inspection was not run because Docker is unavailable in the execution environment. The repository-wide format check still reports the pre-existing `src/constants/config.ts` formatting issue.
