### PR TITLE
fix(docker): tolerate missing yarn shims

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./src/types.g.ts ./
-RUN unlink /usr/local/bin/yarn && unlink /usr/local/bin/yarnpkg && npm install -g corepack@latest
+RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && npm install -g corepack@latest
 RUN corepack enable pnpm && pnpm i --frozen-lockfile
 
 FROM base AS builder
@@ -27,7 +27,7 @@ ENV NEXT_PUBLIC_PP_TOKEN=$NEXT_PUBLIC_PP_TOKEN
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN unlink /usr/local/bin/yarn && unlink /usr/local/bin/yarnpkg && npm install -g corepack@latest
+RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && npm install -g corepack@latest
 RUN corepack enable pnpm && pnpm run build
 
 # Production image, copy all the files and run next


### PR DESCRIPTION
## Summary

- make Yarn shim cleanup idempotent in the dependency and builder stages
- preserve the existing Corepack and pnpm build flow

## Root cause

The Node 26 image does not always include `/usr/local/bin/yarn` and `/usr/local/bin/yarnpkg`. The previous `unlink` commands exited with an error when either path was absent, stopping the Docker build before Corepack installation.

## Impact

Docker builds now tolerate both present and absent Yarn shims while still removing them before installing the latest Corepack release.

## Validation

- `git diff --check`
- pre-commit hook passed
- full Docker build not run because Docker is unavailable in the local environment
