### PR TITLE
fix(ui): resolve accessibility lint errors

### DIFF
--- a/src/app/dash/[userid]/admin/content.tsx
+++ b/src/app/dash/[userid]/admin/content.tsx
@@ -43,7 +43,11 @@ function HomelessBookTableRow({ row }: { row: Row<homelessBookTableItem> }) {
           )
         }
         return (
-          <td key={cell.id} className="px-6 py-5">
+          <td
+            key={cell.id}
+            aria-label={cell.row.original.name}
+            className="px-6 py-5"
+          >
             <div className="flex items-center gap-3">
               <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-blue-100 transition-colors duration-200 group-hover:bg-blue-200 dark:bg-blue-900/30 dark:group-hover:bg-blue-900/50">
                 <BookOpen className="h-4 w-4 text-blue-600 dark:text-blue-400" />

--- a/src/app/dash/[userid]/upload/content.tsx
+++ b/src/app/dash/[userid]/upload/content.tsx
@@ -126,6 +126,10 @@ function UploaderPageContent({ profile }: Props) {
           </div>
 
           <button
+            type="button"
+            role="switch"
+            aria-checked={isOn}
+            aria-label={t('app.upload.private.toggle') ?? 'Toggle private mode'}
             onClick={() => onSwitchChange(!isOn)}
             className={`relative inline-flex h-6 w-12 items-center rounded-full transition-colors ${isOn ? 'bg-green-500' : 'bg-gray-400'} `}
           >

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -10,8 +10,7 @@ function Loading() {
         className="absolute -right-32 -bottom-32 h-96 w-96 rounded-full bg-indigo-400/20 blur-3xl dark:bg-indigo-400/10"
       />
 
-      <div
-        role="status"
+      <output
         aria-live="polite"
         className="relative flex w-full max-w-sm flex-col items-center rounded-3xl border border-white/70 bg-white/70 px-8 py-10 text-center shadow-xl shadow-blue-950/5 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/20"
       >
@@ -33,7 +32,7 @@ function Loading() {
           className="mt-7 h-8 w-8 animate-spin rounded-full border-3 border-blue-400/20 border-t-blue-500"
         />
         <span className="sr-only">Loading ClippingKK</span>
-      </div>
+      </output>
     </main>
   )
 }

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -33,6 +33,7 @@ function Avatar(props: AvatarProps) {
     return props.onClick ? (
       <button
         type="button"
+        aria-label={props.name ? `Edit ${props.name}'s avatar` : 'Edit avatar'}
         className={`animate-pulse rounded-full border-none bg-gray-500 p-0 ${cls}`}
         onClick={props.onClick}
       />

--- a/src/components/book-info-changer/bookCandidate.tsx
+++ b/src/components/book-info-changer/bookCandidate.tsx
@@ -18,73 +18,76 @@ function BookCandidate(props: BookCandidateProps) {
   const { book, selected } = props
 
   return (
-    <li
-      className={cn(
-        'flex cursor-pointer items-start gap-3 rounded-lg p-3',
-        'transition-all duration-200 ease-in-out',
-        'border',
-        selected
-          ? 'ring-primary dark:bg-primary/20 border-slate-200 bg-slate-200/10 shadow-lg ring-2'
-          : 'hover:border-primary/50 dark:hover:border-primary/70 border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800/50',
-        'transform hover:-translate-y-0.5 hover:shadow-xl'
-      )}
-      onClick={() => props.onSelecte(book)}
-      data-selected={selected}
-    >
-      <div className="flex-shrink-0">
-        <BlurhashImage
-          width={80} // Adjusted size for a more compact list item
-          height={112} // Maintain aspect ratio
-          src={book.image}
-          alt={book.title}
-          className="rounded-md object-cover shadow-sm"
-          blurhashValue={
-            book.edges?.imageInfo?.blurHashValue ??
-            'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
-          }
-        />
-      </div>
-      <div className="flex-grow overflow-hidden">
-        <h3 className="truncate text-base font-semibold text-gray-800 sm:text-lg dark:text-gray-100">
-          {book.title}
-        </h3>
-        {book.originTitle && (
-          <h4 className="truncate text-sm text-gray-600 dark:text-gray-400">
-            {book.originTitle}
-          </h4>
+    <li>
+      <button
+        type="button"
+        className={cn(
+          'flex w-full cursor-pointer items-start gap-3 rounded-lg p-3 text-left',
+          'transition-all duration-200 ease-in-out',
+          'border',
+          selected
+            ? 'ring-primary dark:bg-primary/20 border-slate-200 bg-slate-200/10 shadow-lg ring-2'
+            : 'hover:border-primary/50 dark:hover:border-primary/70 border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800/50',
+          'transform hover:-translate-y-0.5 hover:shadow-xl'
         )}
-        {book.author && (
-          <p className="mt-0.5 truncate text-xs text-gray-500 sm:text-sm dark:text-gray-400">
-            {book.author}
-          </p>
-        )}
-        <div className="mt-1 flex items-center">
-          {book.rating !== undefined && book.rating !== null && (
-            <Tooltip
-              content={t('app.book.bookCandidate.ratingTooltip', {
-                rating: book.rating.toFixed(1),
-              })}
-            >
-              <div className="flex items-center">
-                <Rating rating={book.rating} />
-                <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
-                  ({book.rating.toFixed(1)})
-                </span>
-              </div>
-            </Tooltip>
+        onClick={() => props.onSelecte(book)}
+        data-selected={selected}
+      >
+        <div className="flex-shrink-0">
+          <BlurhashImage
+            width={80} // Adjusted size for a more compact list item
+            height={112} // Maintain aspect ratio
+            src={book.image}
+            alt={book.title}
+            className="rounded-md object-cover shadow-sm"
+            blurhashValue={
+              book.edges?.imageInfo?.blurHashValue ??
+              'LEHV6nWB2yk8pyo0adR*.7kCMdnj'
+            }
+          />
+        </div>
+        <div className="flex-grow overflow-hidden">
+          <h3 className="truncate text-base font-semibold text-gray-800 sm:text-lg dark:text-gray-100">
+            {book.title}
+          </h3>
+          {book.originTitle && (
+            <h4 className="truncate text-sm text-gray-600 dark:text-gray-400">
+              {book.originTitle}
+            </h4>
+          )}
+          {book.author && (
+            <p className="mt-0.5 truncate text-xs text-gray-500 sm:text-sm dark:text-gray-400">
+              {book.author}
+            </p>
+          )}
+          <div className="mt-1 flex items-center">
+            {book.rating !== undefined && book.rating !== null && (
+              <Tooltip
+                content={t('app.book.bookCandidate.ratingTooltip', {
+                  rating: book.rating.toFixed(1),
+                })}
+              >
+                <div className="flex items-center">
+                  <Rating rating={book.rating} />
+                  <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
+                    ({book.rating.toFixed(1)})
+                  </span>
+                </div>
+              </Tooltip>
+            )}
+          </div>
+          {book.press && (
+            <p className="mt-1 truncate text-xs text-gray-400 dark:text-gray-500">
+              {book.press}
+            </p>
+          )}
+          {book.summary && (
+            <p className="mt-2 line-clamp-2 text-xs text-gray-600 sm:text-sm dark:text-gray-300">
+              {book.summary}
+            </p>
           )}
         </div>
-        {book.press && (
-          <p className="mt-1 truncate text-xs text-gray-400 dark:text-gray-500">
-            {book.press}
-          </p>
-        )}
-        {book.summary && (
-          <p className="mt-2 line-clamp-2 text-xs text-gray-600 sm:text-sm dark:text-gray-300">
-            {book.summary}
-          </p>
-        )}
-      </div>
+      </button>
     </li>
   )
 }

--- a/src/components/clipping-item/book-clippings-toolbar.tsx
+++ b/src/components/clipping-item/book-clippings-toolbar.tsx
@@ -50,8 +50,7 @@ function BookClippingsToolbar(props: BookClippingsToolbarProps) {
       <div className="flex flex-wrap items-center gap-2">
         {/* Sort segmented toggle */}
         {showSort && (
-          <div
-            role="group"
+          <fieldset
             aria-label="Sort"
             className="flex items-center gap-0.5 rounded-xl border border-slate-200/70 bg-white/60 p-1 backdrop-blur-sm dark:border-slate-700/60 dark:bg-slate-800/50"
           >
@@ -85,12 +84,11 @@ function BookClippingsToolbar(props: BookClippingsToolbarProps) {
                 {t('app.clippings.toolbar.sort.oldest')}
               </span>
             </button>
-          </div>
+          </fieldset>
         )}
 
         {/* View mode toggle */}
-        <div
-          role="group"
+        <fieldset
           aria-label="View"
           className="flex items-center gap-0.5 rounded-xl border border-slate-200/70 bg-white/60 p-1 backdrop-blur-sm dark:border-slate-700/60 dark:bg-slate-800/50"
         >
@@ -122,7 +120,7 @@ function BookClippingsToolbar(props: BookClippingsToolbarProps) {
           >
             <ListIcon size={14} />
           </button>
-        </div>
+        </fieldset>
       </div>
     </div>
   )

--- a/src/components/profile-tabs/profile-tabs.tsx
+++ b/src/components/profile-tabs/profile-tabs.tsx
@@ -99,6 +99,7 @@ const ProfileTabs = ({
 
           <div
             role="tablist"
+            tabIndex={-1}
             aria-label="Profile sections"
             onKeyDown={onTabKeyDown}
             className="relative flex rounded-2xl border border-white/40 bg-white/70 p-1.5 shadow-sm backdrop-blur-xl dark:border-slate-800/40 dark:bg-slate-900/70"

--- a/src/components/searchbar/searchbar.tsx
+++ b/src/components/searchbar/searchbar.tsx
@@ -22,7 +22,7 @@ function SearchBar(props: SearchBarProps) {
   const { t } = useTranslation()
   const [doQuery, { data, loading, called }] = useLazyQuery(SearchQueryDocument)
   const inputRef = useRef<HTMLInputElement>(null)
-  const modalRef = useRef<HTMLDivElement>(null)
+  const modalRef = useRef<HTMLDialogElement>(null)
   const [searchText, setSearchText] = useState('')
 
   const throttleTimeoutRef = useRef<NodeJS.Timeout | null>(null)
@@ -100,10 +100,10 @@ function SearchBar(props: SearchBarProps) {
         onClick={onClose}
         aria-hidden="true"
       />
-      <div
+      <dialog
+        open
         ref={modalRef}
-        className="with-slide-in relative w-full max-w-xl overflow-hidden rounded-lg shadow-2xl md:max-w-3xl lg:max-w-4xl xl:max-w-5xl"
-        role="dialog"
+        className="with-slide-in relative w-full max-w-xl overflow-hidden rounded-lg border-0 bg-transparent p-0 shadow-2xl md:max-w-3xl lg:max-w-4xl xl:max-w-5xl"
         aria-modal="true"
         aria-labelledby="search-modal-title"
       >
@@ -158,7 +158,7 @@ function SearchBar(props: SearchBarProps) {
             </ul>
           </div>
         </div>
-      </div>
+      </dialog>
     </div>
   )
 }

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -33,7 +33,9 @@ export const APP_API_STEP_LIMIT = 10
 export const APP_URL_ORIGIN = __DEV__
   ? 'http://localhost:3101'
   : 'https://clippingkk.annatarhe.com'
-export const CF_TURNSTILE_SITE_KEY = __DEV__ ? '1x00000000000000000000AA' : '0x4AAAAAAAA361EJRDzUhf_b'
+export const CF_TURNSTILE_SITE_KEY = __DEV__
+  ? '1x00000000000000000000AA'
+  : '0x4AAAAAAAA361EJRDzUhf_b'
 
 export const StripePremiumPriceId = __DEV__
   ? 'price_1Md7IUBkj5y79CYsLpkamBZm'


### PR DESCRIPTION
## Summary

- replace inaccessible generic elements with native interactive and semantic elements
- add accessible names and state metadata to avatar, upload, profile-tab, and admin controls
- format the Turnstile configuration expression to satisfy the repository formatter

## Why

Recent accessibility lint rules identified unlabeled controls, non-interactive click targets, and generic elements carrying roles that have native HTML equivalents. These errors caused `pnpm lint` to fail. The configuration file also failed `pnpm format:check`.

## Impact

Interactive UI remains functionally equivalent while gaining keyboard-accessible controls and clearer assistive-technology semantics. Lint, formatting, and both TypeScript configurations now pass.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm typecheck:server`
- `pnpm test` (14 files, 31 tests)
- `git diff --check`
