### PR TITLE
fix(clippings): bind same-title clippings together

### DIFF
--- a/src/server/__tests__/resolvers.test.ts
+++ b/src/server/__tests__/resolvers.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment node
 
+import type { SQL } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+
 import {
   clippings,
   nouns,
@@ -145,4 +148,85 @@ test('selects only legacy-compatible noun fields when creating clippings', async
     }),
   ])
   expect(cacheDeleteMock).toHaveBeenCalledWith('ck:books:2')
+})
+
+test('updates all active same-title clippings owned by the current user', async () => {
+  const updatedAt = new Date('2026-08-01T12:00:00.000Z')
+  vi.useFakeTimers()
+  vi.setSystemTime(updatedAt)
+
+  const clipping = {
+    id: 11,
+    title: 'Example book',
+    bookId: '0',
+    createdBy: 2,
+  } as Clipping
+  const sibling = {
+    ...clipping,
+    id: 12,
+    bookId: '37005453',
+    updatedAt,
+  } as Clipping
+  const updatedClipping = {
+    ...clipping,
+    bookId: '37005453',
+    updatedAt,
+  } as Clipping
+
+  const findFirst = vi.fn().mockResolvedValue(clipping)
+  const returning = vi.fn().mockResolvedValue([sibling, updatedClipping])
+  const where = vi.fn((_condition: SQL) => ({ returning }))
+  const set = vi.fn(() => ({ where }))
+  const update = vi.fn(() => ({ set }))
+  getDatabaseMock.mockReturnValue({
+    db: {
+      query: { clippings: { findFirst } },
+      update,
+    },
+  })
+
+  await expect(
+    resolvers.Mutation.updateClippingBookId(
+      {},
+      { clippingId: clipping.id, doubanId: 37005453 },
+      { userId: 2 } as GraphQLContext
+    )
+  ).resolves.toEqual(updatedClipping)
+
+  expect(update).toHaveBeenCalledWith(clippings)
+  expect(set).toHaveBeenCalledWith({ bookId: '37005453', updatedAt })
+  expect(returning).toHaveBeenCalledOnce()
+
+  const condition = where.mock.calls[0]?.[0]
+  expect(condition).toBeDefined()
+  const query = new PgDialect().sqlToQuery(condition!)
+  expect(query.sql).toBe(
+    '("clippings"."created_by" = $1 and "clippings"."title" = $2 and "clippings"."deleted_at" is null)'
+  )
+  expect(query.params).toEqual([2, 'Example book'])
+})
+
+test('rejects a book update for a clipping owned by another user', async () => {
+  const findFirst = vi.fn().mockResolvedValue({
+    id: 11,
+    title: 'Example book',
+    bookId: '0',
+    createdBy: 3,
+  } as Clipping)
+  const update = vi.fn()
+  getDatabaseMock.mockReturnValue({
+    db: {
+      query: { clippings: { findFirst } },
+      update,
+    },
+  })
+
+  await expect(
+    resolvers.Mutation.updateClippingBookId(
+      {},
+      { clippingId: 11, doubanId: 37005453 },
+      { userId: 2 } as GraphQLContext
+    )
+  ).rejects.toThrow('not your clipping')
+  expect(update).not.toHaveBeenCalled()
 })

--- a/src/server/graphql/resolvers.ts
+++ b/src/server/graphql/resolvers.ts
@@ -994,18 +994,21 @@ export const resolvers: Record<string, Record<string, any>> = {
       const clipping = await clippingById(args.clippingId)
       if (clipping.createdBy !== uid)
         throw new ApiError('not your clipping', 403)
-      const [updated] = await db()
+      const updated = await db()
         .update(clippings)
         .set({ bookId: String(args.doubanId), updatedAt: new Date() })
         .where(
           and(
-            eq(clippings.id, clipping.id),
             eq(clippings.createdBy, uid),
+            eq(clippings.title, clipping.title),
             activeClipping
           )
         )
         .returning()
-      return assertFound(updated, 'clipping not found')
+      return assertFound(
+        updated.find((item) => item.id === clipping.id),
+        'clipping not found'
+      )
     },
     createComment: async (_: unknown, args: Args, context: GraphQLContext) => {
       await clippingById(args.cid)


### PR DESCRIPTION
## Summary

- bind every active clipping with the same exact title owned by the current user when `updateClippingBookId` runs
- preserve the existing GraphQL mutation signature and returned clipping
- add regression coverage for bulk matching and ownership enforcement

## Root cause

The resolver updated only the submitted clipping ID. Same-title sibling clippings therefore kept `bookId = '0'` and continued to appear on the unchecked page after its query refreshed.

## Impact

Submitting a book ID once now consistently rebinds the current user's matching clippings while leaving other users' and deleted clippings unchanged.

## Validation

- `pnpm test` — 14 files, 33 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint` — passed with pre-existing warnings
