### PR TITLE
perf(rsc): execute server-side GraphQL in-process instead of over the public domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,12 @@ const response = await doApolloServerQuery<ProfileQuery>({
 const { data, loading } = useProfileQuery({ variables: { id } })
 ```
 
+The GraphQL API lives in this same project (`src/app/api/v2/graphql/route.ts`, backed by
+`src/server/graphql/`). Server components therefore execute **in-process** against the yoga
+instance via `src/server/graphql/local-transport.ts` — no socket, no DNS, no TLS. Only the
+browser client talks HTTP. Never point the server Apollo client at an absolute origin; that
+reintroduces a public round-trip to reach code already loaded in the same process.
+
 ### Server-Client Data Flow
 
 Server components prefetch with React Query, client hydrates:
@@ -102,7 +108,8 @@ const dehydratedState = dehydrate(rq)
 - `src/services/apollo.server.ts` - Server-side Apollo Client setup
 - `src/services/apollo.shard.ts` - Shared Apollo configuration
 - `src/services/wenqu.ts` - External book service API
-- `src/services/urls.ts` - URL constants and routing
+- `src/server/graphql/yoga.ts` - The graphql-yoga instance shared by the route handler and RSC
+- `src/server/graphql/local-transport.ts` - In-process GraphQL transport for server components
 
 **Generated Code:**
 

--- a/src/app/api/v2/graphql/route.ts
+++ b/src/app/api/v2/graphql/route.ts
@@ -1,19 +1,7 @@
-import { createYoga } from 'graphql-yoga'
-
-import { createGraphQLContext } from '@/server/graphql/context'
-import { graphQLSchema } from '@/server/graphql/schema'
+import { yoga } from '@/server/graphql/yoga'
 import { options, route } from '@/server/http'
 
 export const maxDuration = 180
-
-const yoga = createYoga({
-  schema: graphQLSchema,
-  graphqlEndpoint: '/api/v2/graphql',
-  context: createGraphQLContext,
-  cors: false,
-  graphiql: process.env.NODE_ENV !== 'production',
-  maskedErrors: process.env.NODE_ENV === 'production',
-})
 
 const handler = route(async (request) => yoga.fetch(request), 'graphql.request')
 

--- a/src/server/__tests__/graphql-local-transport.test.ts
+++ b/src/server/__tests__/graphql-local-transport.test.ts
@@ -1,0 +1,102 @@
+import { headers } from 'next/headers'
+
+import {
+  LOCAL_GRAPHQL_URL,
+  localGraphQLFetch,
+} from '../graphql/local-transport'
+import { yoga } from '../graphql/yoga'
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(),
+}))
+
+vi.mock('../graphql/yoga', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../graphql/yoga')>()
+  return {
+    ...actual,
+    yoga: { fetch: vi.fn() },
+  }
+})
+
+const yogaFetch = vi.mocked(yoga.fetch)
+
+function ok() {
+  return new Response(JSON.stringify({ data: { __typename: 'Query' } }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  vi.mocked(headers).mockResolvedValue(new Headers() as never)
+  yogaFetch.mockResolvedValue(ok() as never)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function post(body: unknown, init: RequestInit = {}) {
+  return localGraphQLFetch(LOCAL_GRAPHQL_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    ...init,
+  })
+}
+
+test('hands the operation to the in-process schema without opening a socket', async () => {
+  const fetchMock = vi.fn(() => {
+    throw new Error('the network must not be touched')
+  })
+  vi.stubGlobal('fetch', fetchMock)
+
+  const response = await post({ query: '{ __typename }' })
+
+  expect(response.status).toBe(200)
+  expect(fetchMock).not.toHaveBeenCalled()
+  expect(yogaFetch).toHaveBeenCalledOnce()
+
+  const request = yogaFetch.mock.calls[0][0] as unknown as Request
+  expect(request.method).toBe('POST')
+  // The path has to keep matching yoga's graphqlEndpoint or it answers 404.
+  expect(new URL(request.url).pathname).toBe('/api/v2/graphql')
+  await expect(request.json()).resolves.toEqual({ query: '{ __typename }' })
+})
+
+test('preserves the caller Authorization header', async () => {
+  await post(
+    { query: '{ __typename }' },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer server-side-token',
+      },
+    }
+  )
+
+  const request = yogaFetch.mock.calls[0][0] as unknown as Request
+  expect(request.headers.get('Authorization')).toBe('Bearer server-side-token')
+})
+
+test('forwards the real client ip so resolvers do not see the server itself', async () => {
+  vi.mocked(headers).mockResolvedValue(
+    new Headers({ 'x-forwarded-for': '203.0.113.7, 10.0.0.1' }) as never
+  )
+
+  await post({ query: '{ __typename }' })
+
+  const request = yogaFetch.mock.calls[0][0] as unknown as Request
+  expect(request.headers.get('x-forwarded-for')).toBe('203.0.113.7, 10.0.0.1')
+})
+
+test('still works outside a request scope, such as at build time', async () => {
+  vi.mocked(headers).mockRejectedValue(
+    new Error('called outside a request scope')
+  )
+
+  const response = await post({ query: '{ __typename }' })
+
+  expect(response.status).toBe(200)
+  expect(yogaFetch).toHaveBeenCalledOnce()
+})

--- a/src/server/graphql/local-transport.ts
+++ b/src/server/graphql/local-transport.ts
@@ -1,0 +1,38 @@
+import { trace } from '@opentelemetry/api'
+import { withSpan } from '@superlog/otel-helpers'
+import { headers } from 'next/headers'
+
+import { GRAPHQL_ENDPOINT, yoga } from './yoga'
+
+const tracer = trace.getTracer('clippingkk.web.graphql.local')
+
+// This origin is never dialed. It only keeps the URL well-formed for `new Request`,
+// and the path has to match GRAPHQL_ENDPOINT or yoga answers with a 404.
+export const LOCAL_GRAPHQL_URL = `http://localhost${GRAPHQL_ENDPOINT}`
+
+/**
+ * A fetch-shaped transport that hands the request straight to the in-process yoga
+ * instance instead of opening a socket back to our own public origin. Keeps yoga's
+ * context creation, error masking and response shape, so Apollo's HttpLink needs no
+ * special casing.
+ */
+export const localGraphQLFetch = (async (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => {
+  const request = new Request(input, init)
+
+  try {
+    const incoming = await headers()
+    const forwardedFor = incoming.get('x-forwarded-for')
+    if (forwardedFor) {
+      request.headers.set('x-forwarded-for', forwardedFor)
+    }
+  } catch {
+    // no request scope (build time / prerender) — nothing to forward
+  }
+
+  return withSpan('graphql.local.request', () => yoga.fetch(request), {
+    tracer,
+  })
+}) as typeof fetch

--- a/src/server/graphql/yoga.ts
+++ b/src/server/graphql/yoga.ts
@@ -1,0 +1,15 @@
+import { createYoga } from 'graphql-yoga'
+
+import { createGraphQLContext } from './context'
+import { graphQLSchema } from './schema'
+
+export const GRAPHQL_ENDPOINT = '/api/v2/graphql'
+
+export const yoga = createYoga({
+  schema: graphQLSchema,
+  graphqlEndpoint: GRAPHQL_ENDPOINT,
+  context: createGraphQLContext,
+  cors: false,
+  graphiql: process.env.NODE_ENV !== 'production',
+  maskedErrors: process.env.NODE_ENV === 'production',
+})

--- a/src/services/__tests__/ajax.test.ts
+++ b/src/services/__tests__/ajax.test.ts
@@ -5,6 +5,7 @@ import {
   isUnauthorizedApolloError,
   request,
   requestJson,
+  resolveApiBase,
   updateToken,
 } from '@/services/ajax'
 
@@ -95,6 +96,29 @@ describe('HTTP client helpers', () => {
 
     await expect(request('/v2/example')).rejects.toThrow('not allowed')
     expect(toast.error).toHaveBeenCalledOnce()
+  })
+
+  it('keeps URLs relative in the browser', () => {
+    expect(resolveApiBase()).toBe('')
+  })
+
+  it('targets loopback on the server so requests never leave the box', () => {
+    vi.stubGlobal('window', undefined)
+    vi.stubEnv('PORT', '3000')
+
+    expect(resolveApiBase()).toBe('http://127.0.0.1:3000')
+
+    vi.unstubAllEnvs()
+  })
+
+  it('falls back to the APP_ORIGIN port when PORT is unset', () => {
+    vi.stubGlobal('window', undefined)
+    vi.stubEnv('PORT', '')
+    vi.stubEnv('APP_ORIGIN', 'http://localhost:3101')
+
+    expect(resolveApiBase()).toBe('http://127.0.0.1:3101')
+
+    vi.unstubAllEnvs()
   })
 
   it('recognizes unauthorized GraphQL errors', () => {

--- a/src/services/ajax.ts
+++ b/src/services/ajax.ts
@@ -41,6 +41,26 @@ export function getLocalToken() {
 let token = typeof window === 'undefined' ? null : getLocalToken()
 // let token = localProfile?.token
 
+export function resolveApiBase() {
+  if (API_HOST) {
+    return API_HOST
+  }
+
+  // Browser: same origin, relative URLs are fine.
+  if (typeof window !== 'undefined') {
+    return ''
+  }
+
+  // Server: the API is this same process, so stay on loopback rather than
+  // going back out through the public domain. Node's fetch also rejects the
+  // relative URL a browser would happily accept.
+  const appOriginPort = process.env.APP_ORIGIN
+    ? new URL(process.env.APP_ORIGIN).port
+    : ''
+  const port = process.env.PORT || appOriginPort || '3000'
+  return `http://127.0.0.1:${port}`
+}
+
 export async function request<T>(
   url: string,
   options: RequestInit = {}
@@ -57,7 +77,9 @@ export async function request<T>(
     headers.set('X-Accept-Language', getLanguage())
   }
 
-  const finalUrl = url.startsWith('http') ? url : `${API_HOST}/api${url}`
+  const finalUrl = url.startsWith('http')
+    ? url
+    : `${resolveApiBase()}/api${url}`
 
   try {
     const fetchResponse = await fetch(finalUrl, {
@@ -73,7 +95,9 @@ export async function request<T>(
 
     return response.data
   } catch (e) {
-    toast.error('请求挂了... 一会儿再试试')
+    if (typeof window !== 'undefined') {
+      toast.error('请求挂了... 一会儿再试试')
+    }
     return Promise.reject(e)
   }
 }

--- a/src/services/apollo.server.ts
+++ b/src/services/apollo.server.ts
@@ -12,19 +12,21 @@ import {
 import { redirect } from 'next/navigation'
 import { connection } from 'next/server'
 
-import { API_HOST } from '@/constants/config'
-import { getServerEnv } from '@/server/env'
+import {
+  LOCAL_GRAPHQL_URL,
+  localGraphQLFetch,
+} from '@/server/graphql/local-transport'
 
 import { authLink, isUnauthorizedApolloError } from './ajax'
 import { apolloCacheConfig } from './apollo.shard'
 
-export function getApolloServerGraphqlUrl() {
-  const origin = API_HOST || getServerEnv().APP_ORIGIN
-  return `${origin.replace(/\/$/, '')}/api/v2/graphql`
-}
-
 const { getClient } = registerApolloClient(() => {
-  const httpLink = new HttpLink({ uri: getApolloServerGraphqlUrl() })
+  // The API lives in this very process, so skip the network entirely instead of
+  // paying DNS + TLS + a public load balancer round-trip to reach ourselves.
+  const httpLink = new HttpLink({
+    uri: LOCAL_GRAPHQL_URL,
+    fetch: localGraphQLFetch,
+  })
   return new ApolloClient({
     cache: new InMemoryCache(apolloCacheConfig),
     link: ApolloLink.from([authLink, httpLink]),


### PR DESCRIPTION
## Problem

The API was migrated into this project (#180), so `src/app/api/v2/graphql/route.ts` runs graphql-yoga against `src/server/graphql/schema.ts` with Postgres and Redis in the same Node process.

Server components never picked up on that. `src/services/apollo.server.ts` still built an `HttpLink` against an absolute origin:

```ts
const origin = API_HOST || getServerEnv().APP_ORIGIN
return `${origin.replace(/\/$/, '')}/api/v2/graphql`
```

`NEXT_PUBLIC_API_HOST` is set nowhere in the repo, so `API_HOST === ''` and the server fell through to `APP_ORIGIN` — the **public HTTPS hostname** in production. Every server-rendered GraphQL query did DNS → public load balancer → TLS handshake → back into the same container, to reach resolvers already loaded in the same process. That's ~25 call sites across 15 files, several of them serial per page render.

## Changes

**In-process GraphQL for server components**
- New `src/server/graphql/yoga.ts` holds the yoga instance so the route handler and RSC share one. The route shrinks to a thin wrapper — browser traffic is unchanged.
- New `src/server/graphql/local-transport.ts` exposes a fetch-shaped transport that hands the `Request` straight to `yoga.fetch`. No socket, no DNS, no TLS, and no second pass through the route handler.
- `src/services/apollo.server.ts` uses it as the `HttpLink` fetch. `doApolloServerQuery`, `getApolloServerClient`, the `connection()` call and the unauthorized-redirect behavior are untouched, so **every call site works unchanged** — including the ones passing an explicit `Authorization` header, since `HttpLink` still serializes `context.headers` onto the request that yoga reads.

Yoga keeps building the context, masking errors and shaping the response, so nothing downstream needed special-casing. The `route()` wrapper is deliberately bypassed — its CORS headers and HTTP-span semantics are meaningless in-process — and a `graphql.local.request` span replaces the `graphql.request` one so observability is preserved.

`x-forwarded-for` is now forwarded from the incoming request, so `context.ip` sees the real client rather than the server's own egress IP. Resolvers use it for Turnstile verification and OTP rate limiting.

**Server-side REST fix**

`request()` in `src/services/ajax.ts` built `` `${API_HOST}/api${url}` `` with no server fallback, producing a **relative URL that Node's `fetch` cannot parse**. `src/app/pricing/page.tsx` hits this today via `getPaymentSubscription`. It now resolves a loopback base on the server (`PORT`, falling back to the `APP_ORIGIN` port, then 3000), and the failure toast no longer fires during server rendering.

## Verification

- `vitest run` — 15 files / 40 tests pass, including 4 new ones covering the transport: global `fetch` is never called, the request reaches yoga on the right path with the right body, the caller's `Authorization` survives, the client IP is forwarded, and a missing request scope (build/prerender) degrades gracefully.
- `tsc --noEmit` clean.
- `oxlint` clean for the changed files; `oxfmt` applied.
- `next build --turbopack` exits 0 — confirms pulling the resolver graph into the RSC module graph is fine. It creates no connections at import time, since `getDatabase()` and the redis client are both lazy `globalThis` singletons.

## Notes

- Scoped on the basis that the API is always co-located with the web app, so in-process is unconditional with no transport flag.
- REST stays on loopback HTTP rather than going in-process — those handlers are small and varied, and loopback already removes the DNS/TLS/public-hop cost.
- `CLAUDE.md` updated: it described GraphQL as an external service and pointed at `src/services/urls.ts`, which does not exist.

Spotted but left alone: `src/services/wenqu.ts` hardcodes its host while `WENQU_ENDPOINT`/`WENQU_TOKEN` sit unread in `src/server/env.ts`; `getLanguage()` returns `'en'` for all server-rendered content; `src/services/apollo.shard.ts` exports a duplicate unused `httpLink`; and several call sites build `Bearer undefined` when the token cookie is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TKEAq2qU9JGQDfbmcnM17

---
_Generated by [Claude Code](https://claude.ai/code/session_013TKEAq2qU9JGQDfbmcnM17)_